### PR TITLE
Add end-of-method mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+tags

--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Thur, 09 November 2017
+" Last Change:	Wed, 20 December 2017
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -20,6 +20,9 @@ setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
 setlocal omnifunc=pythoncomplete#Complete
+if has('python3')
+       setlocal omnifunc=python3complete#Complete
+endif
 
 set wildignore+=*.pyc
 

--- a/python.vim
+++ b/python.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin file
 " Language:	python
-" Maintainer:	James Sully <sullyj3@gmail.com>
-" Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Thur, 04 May 2017
-" https://github.com/sullyj3/vim-ftplugin-python
+" Maintainer:	Tom Picton <tom@tompicton.co.uk>
+" Previous Maintainer: James Sully <sullyj3@gmail.com>
+" Last Change:	Fri, 20 October 2017
+" https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1

--- a/python.vim
+++ b/python.vim
@@ -2,7 +2,8 @@
 " Language:	python
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
-" Last Change:	Fri, 20 October 2017
+" Previous Maintainer: Johannes Zellner <johannes@zellner.org>
+" Last Change:	Sat, 04 November 2017
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif

--- a/python.vim
+++ b/python.vim
@@ -2,7 +2,7 @@
 " Language:	python
 " Maintainer:	James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Mon, 01 May 2017
+" Last Change:	Thur, 04 May 2017
 " https://github.com/sullyj3/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif

--- a/python.vim
+++ b/python.vim
@@ -2,7 +2,7 @@
 " Language:	python
 " Maintainer:	James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Tue, 04 October 2016
+" Last Change:	Mon, 01 May 2017
 " https://github.com/sullyj3/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -26,29 +26,41 @@ let b:next_toplevel='\v%$\|^(class\|def\|async def)>'
 let b:prev_toplevel='\v^(class\|def\|async def)>'
 let b:next='\v%$\|^\s*(class\|def\|async def)>'
 let b:prev='\v^\s*(class\|def\|async def)>'
+let b:next_end='\v\S\n*(%$\|^\s*(class\|def\|async def)\|^\S)'
+let b:prev_end='\v\S\n*(^\s*(class\|def\|async def)\|^\S)'
 
 execute "nnoremap <silent> <buffer> ]] :call <SID>Python_jump('n', '". b:next_toplevel."', 'W')<cr>"
 execute "nnoremap <silent> <buffer> [[ :call <SID>Python_jump('n', '". b:prev_toplevel."', 'Wb')<cr>"
 execute "nnoremap <silent> <buffer> ]m :call <SID>Python_jump('n', '". b:next."', 'W')<cr>"
 execute "nnoremap <silent> <buffer> [m :call <SID>Python_jump('n', '". b:prev."', 'Wb')<cr>"
+execute "nnoremap <silent> <buffer> ]M :call <SID>Python_jump('n', '". b:next_end."', 'W', 0)<cr>"
+execute "nnoremap <silent> <buffer> [M :call <SID>Python_jump('n', '". b:prev_end."', 'Wb', 0)<cr>"
 
 execute "onoremap <silent> <buffer> ]] :call <SID>Python_jump('o', '". b:next_toplevel."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [[ :call <SID>Python_jump('o', '". b:prev_toplevel."', 'Wb')<cr>"
 execute "onoremap <silent> <buffer> ]m :call <SID>Python_jump('o', '". b:next."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [m :call <SID>Python_jump('o', '". b:prev."', 'Wb')<cr>"
+execute "onoremap <silent> <buffer> ]M :call <SID>Python_jump('o', '". b:next_end."', 'W', 0)<cr>"
+execute "onoremap <silent> <buffer> [M :call <SID>Python_jump('o', '". b:prev_end."', 'Wb', 0)<cr>"
 
 execute "xnoremap <silent> <buffer> ]] :call <SID>Python_jump('x', '". b:next_toplevel."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [[ :call <SID>Python_jump('x', '". b:prev_toplevel."', 'Wb')<cr>"
 execute "xnoremap <silent> <buffer> ]m :call <SID>Python_jump('x', '". b:next."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [m :call <SID>Python_jump('x', '". b:prev."', 'Wb')<cr>"
+execute "xnoremap <silent> <buffer> ]M :call <SID>Python_jump('x', '". b:next_end."', 'W', 0)<cr>"
+execute "xnoremap <silent> <buffer> [M :call <SID>Python_jump('x', '". b:prev_end."', 'Wb', 0)<cr>"
 
 if !exists('*<SID>Python_jump')
-  fun! <SID>Python_jump(mode, motion, flags) range
+  fun! <SID>Python_jump(mode, motion, flags, ...) range
+      let l:startofline = (a:0 >= 1) ? a:1 : 1
+
       if a:mode == 'x'
           normal! gv
       endif
 
-      normal! 0
+      if l:startofline == 1
+          normal! 0
+      endif
 
       let cnt = v:count1
       mark '
@@ -57,7 +69,9 @@ if !exists('*<SID>Python_jump')
           let cnt = cnt - 1
       endwhile
 
-      normal! ^
+      if l:startofline == 1
+          normal! ^
+      endif
   endfun
 endif
 

--- a/python.vim
+++ b/python.vim
@@ -42,8 +42,8 @@ execute "nnoremap <silent> <buffer> [M :call <SID>Python_jump('n', '". b:prev_en
 
 execute "onoremap <silent> <buffer> ]] :call <SID>Python_jump('o', '". b:next_toplevel."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [[ :call <SID>Python_jump('o', '". b:prev_toplevel."', 'Wb')<cr>"
-execute "onoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
-execute "onoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
+execute "onoremap <silent> <buffer> ][ :call <SID>Python_jump('o', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "onoremap <silent> <buffer> [] :call <SID>Python_jump('o', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "onoremap <silent> <buffer> ]m :call <SID>Python_jump('o', '". b:next."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [m :call <SID>Python_jump('o', '". b:prev."', 'Wb')<cr>"
 execute "onoremap <silent> <buffer> ]M :call <SID>Python_jump('o', '". b:next_end."', 'W', 0)<cr>"
@@ -51,8 +51,8 @@ execute "onoremap <silent> <buffer> [M :call <SID>Python_jump('o', '". b:prev_en
 
 execute "xnoremap <silent> <buffer> ]] :call <SID>Python_jump('x', '". b:next_toplevel."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [[ :call <SID>Python_jump('x', '". b:prev_toplevel."', 'Wb')<cr>"
-execute "xnoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
-execute "xnoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
+execute "xnoremap <silent> <buffer> ][ :call <SID>Python_jump('x', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "xnoremap <silent> <buffer> [] :call <SID>Python_jump('x', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "xnoremap <silent> <buffer> ]m :call <SID>Python_jump('x', '". b:next."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [m :call <SID>Python_jump('x', '". b:prev."', 'Wb')<cr>"
 execute "xnoremap <silent> <buffer> ]M :call <SID>Python_jump('x', '". b:next_end."', 'W', 0)<cr>"

--- a/python.vim
+++ b/python.vim
@@ -24,6 +24,8 @@ set wildignore+=*.pyc
 
 let b:next_toplevel='\v%$\|^(class\|def\|async def)>'
 let b:prev_toplevel='\v^(class\|def\|async def)>'
+let b:next_endtoplevel='\v%$\|\S.*\n+(def\|class)'
+let b:prev_endtoplevel='\v\S.*\n+(def\|class)'
 let b:next='\v%$\|^\s*(class\|def\|async def)>'
 let b:prev='\v^\s*(class\|def\|async def)>'
 let b:next_end='\v\S\n*(%$\|^\s*(class\|def\|async def)\|^\S)'
@@ -31,6 +33,8 @@ let b:prev_end='\v\S\n*(^\s*(class\|def\|async def)\|^\S)'
 
 execute "nnoremap <silent> <buffer> ]] :call <SID>Python_jump('n', '". b:next_toplevel."', 'W')<cr>"
 execute "nnoremap <silent> <buffer> [[ :call <SID>Python_jump('n', '". b:prev_toplevel."', 'Wb')<cr>"
+execute "nnoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "nnoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "nnoremap <silent> <buffer> ]m :call <SID>Python_jump('n', '". b:next."', 'W')<cr>"
 execute "nnoremap <silent> <buffer> [m :call <SID>Python_jump('n', '". b:prev."', 'Wb')<cr>"
 execute "nnoremap <silent> <buffer> ]M :call <SID>Python_jump('n', '". b:next_end."', 'W', 0)<cr>"
@@ -38,6 +42,8 @@ execute "nnoremap <silent> <buffer> [M :call <SID>Python_jump('n', '". b:prev_en
 
 execute "onoremap <silent> <buffer> ]] :call <SID>Python_jump('o', '". b:next_toplevel."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [[ :call <SID>Python_jump('o', '". b:prev_toplevel."', 'Wb')<cr>"
+execute "onoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "onoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "onoremap <silent> <buffer> ]m :call <SID>Python_jump('o', '". b:next."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [m :call <SID>Python_jump('o', '". b:prev."', 'Wb')<cr>"
 execute "onoremap <silent> <buffer> ]M :call <SID>Python_jump('o', '". b:next_end."', 'W', 0)<cr>"
@@ -45,6 +51,8 @@ execute "onoremap <silent> <buffer> [M :call <SID>Python_jump('o', '". b:prev_en
 
 execute "xnoremap <silent> <buffer> ]] :call <SID>Python_jump('x', '". b:next_toplevel."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [[ :call <SID>Python_jump('x', '". b:prev_toplevel."', 'Wb')<cr>"
+execute "xnoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "xnoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "xnoremap <silent> <buffer> ]m :call <SID>Python_jump('x', '". b:next."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [m :call <SID>Python_jump('x', '". b:prev."', 'Wb')<cr>"
 execute "xnoremap <silent> <buffer> ]M :call <SID>Python_jump('x', '". b:next_end."', 'W', 0)<cr>"

--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Sat, 04 November 2017
+" Last Change:	Thur, 09 November 2017
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -29,8 +29,8 @@ let b:next_endtoplevel='\v%$\|\S.*\n+(def\|class)'
 let b:prev_endtoplevel='\v\S.*\n+(def\|class)'
 let b:next='\v%$\|^\s*(class\|def\|async def)>'
 let b:prev='\v^\s*(class\|def\|async def)>'
-let b:next_end='\v\S\n*(%$\|^\s*(class\|def\|async def)\|^\S)'
-let b:prev_end='\v\S\n*(^\s*(class\|def\|async def)\|^\S)'
+let b:next_end='\v\S\n*(%$\|^(\s*\n*)*(class\|def\|async def)\|^\S)'
+let b:prev_end='\v\S\n*(^(\s*\n*)*(class\|def\|async def)\|^\S)'
 
 execute "nnoremap <silent> <buffer> ]] :call <SID>Python_jump('n', '". b:next_toplevel."', 'W')<cr>"
 execute "nnoremap <silent> <buffer> [[ :call <SID>Python_jump('n', '". b:prev_toplevel."', 'Wb')<cr>"


### PR DESCRIPTION
Currently the `]M`/`[M` behaviour is a bit wonky since it's still looking for C syntax. The mappings I've suggested will match the last non-whitespace character of a line above a class/method definition or above any line at indent level 0.

This matches the `]m`/`[m` behaviour nicely, but chokes on import statements, non-OO structures etc. I think this is acceptable as you see similar behaviour in other filetypes but I'm open to suggestions.