### PR TITLE
Conditionally set omnifunc

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -18,7 +18,9 @@ setlocal suffixesadd=.py
 setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
-setlocal omnifunc=pythoncomplete#Complete
+if &omnifunc != ''
+  setlocal omnifunc=pythoncomplete#Complete
+endif
 
 set wildignore+=*.pyc
 


### PR DESCRIPTION
The option &omnifunc is now checked before setting it to pythoncomplete#Complete.
Possible fix for cumbersome setting of a custom omnifunc for python as described in #9 .